### PR TITLE
Fixes the wrapping of the blocks on the main page

### DIFF
--- a/style.css
+++ b/style.css
@@ -100,7 +100,8 @@ img {
 	font-size: x-large;
 	text-decoration: none;
 	text-align: center;
-	display: block;
+	display: inline-block;
+	width: 80%;
 	padding: 1em;
 	margin: 1em;
 	border-radius: .5em;


### PR DESCRIPTION
The navigation blocks on the main index.html page wrapped such that the Forum block was split between the first and second column.  This fixes the blocks so that they wrap properly, regardless of screen width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader.github.io/11)
<!-- Reviewable:end -->
